### PR TITLE
adding p4d.24xlarge + Multiple EFA Support + GPUDirect RDMA during EFA install

### DIFF
--- a/assets/efa-nodegroup.yaml
+++ b/assets/efa-nodegroup.yaml
@@ -82,7 +82,7 @@ Parameters:
 
   NodeImageIdSSMParam:
     Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
-    Default: /aws/service/eks/optimized-ami/1.16/amazon-linux-2-gpu/recommended/image_id
+    Default: /aws/service/eks/optimized-ami/1.18/amazon-linux-2-gpu/recommended/image_id
     Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
 
   NodeInstanceType:
@@ -243,6 +243,7 @@ Parameters:
       - p3.2xlarge
       - p3.8xlarge
       - p3.16xlarge
+      - p4d.24xlarge
       - p3dn.24xlarge
       - g4dn.xlarge
       - g4dn.2xlarge
@@ -557,7 +558,29 @@ Resources:
         KeyName: !Ref KeyName
         NetworkInterfaces:
           - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 0
             DeviceIndex: 0
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+            SubnetId: !Ref SubnetId
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 1
+            DeviceIndex: 1
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+            SubnetId: !Ref SubnetId
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 2
+            DeviceIndex: 2
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+            SubnetId: !Ref SubnetId
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 3
+            DeviceIndex: 3
             Groups:
               - !Ref NodeSecurityGroup
             InterfaceType: efa
@@ -576,7 +599,7 @@ Resources:
 
             cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
             pushd /tmp/aws-efa-installer
-            cloud-init-per once install_efa ./efa_installer.sh -y
+            cloud-init-per once install_efa ./efa_installer.sh -y -g
             pop /tmp/aws-efa-installer
 
             cloud-init-per once efa_info /opt/amazon/efa/bin/fi_info -p efa


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1) Adding p4d.24xlarge instance type to list of instance types
2) Adding NetworCardIndex to support multiple EFA ENIs per p4d.24xlarge
3) Enabling GPUDirect RDMA during EFA install
4) Updating the EKS Optimized AMI to 1.18

- I would suggest creating a separate branch for p4d as these changes are p4d specific

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
